### PR TITLE
Add support for snap

### DIFF
--- a/keepassxc_proxy_client/protocol.py
+++ b/keepassxc_proxy_client/protocol.py
@@ -88,6 +88,9 @@ class Connection:
             flatpak_socket_path = os.path.join(os.environ["XDG_RUNTIME_DIR"], "app/org.keepassxc.KeePassXC", server_name)
             if os.path.exists(flatpak_socket_path):
                 return flatpak_socket_path
+            snap_socket_path= os.path.join(os.environ["HOME"], "snap/keepassxc/common", server_name)
+            if os.path.exists(snap_socket_path):
+                return snap_socket_path
             return os.path.join(os.environ["XDG_RUNTIME_DIR"], server_name)
         elif system == "Darwin" and "TMPDIR" in os.environ:
             return os.path.join(os.getenv("TMPDIR"), server_name)


### PR DESCRIPTION
Snap is a popular software packaging and distribution system. When keepassxc was distributed by snap, the proxy can not read the /tmp directory because it is sandboxed (as for flatpak packages).
The socket can be read in the $SNAP_COMMON directory mentioned in this documentation : https://snapcraft.io/docs/data-locations

This PR aims at adding support for snap packages keepassxc by checking the existence of this directory before returning the default location for the socket (the same way for flatpak)