### PR TITLE
feat: Add support for Cygwin

### DIFF
--- a/keepassxc_proxy_client/protocol.py
+++ b/keepassxc_proxy_client/protocol.py
@@ -4,14 +4,13 @@ import socket
 import json
 import platform
 import os
+import getpass
 
 import nacl.utils
 from nacl.public import PrivateKey, Box, PublicKey
 
 if platform.system() == "Windows":
 	import win32file
-	import getpass
-	
 
 
 class ResponseUnsuccesfulException(Exception):
@@ -57,14 +56,42 @@ class WinNamedPipe:
         _, data = win32file.ReadFile(self.handle, buff_size)
         return data
 
+
+class CygwinPipe:
+    def __init__(self):
+        self.fd = None
+
+    def connect(self, address):
+        try:
+            self.fd = os.open(r"\\.\pipe\%s" % address, os.O_RDWR | os.O_BINARY)
+        except Exception as e:
+            raise Exception(
+                "Error: Connection could not be established to pipe {addr}".format(addr=address), e
+            )
+
+    def close(self):
+        if self.fd is not None:
+            os.close(self.fd)
+            self.fd = None
+
+    def sendall(self, message):
+        os.write(self.fd, message)
+
+    def recv(self, buff_size):
+        return os.read(self.fd, buff_size)
+
+
 class Connection:
     def __init__(self):
         self.private_key = PrivateKey.generate()
         self.public_key = self.private_key.public_key
         self.nonce = nacl.utils.random(24)
         self.client_id = base64.b64encode(nacl.utils.random(24)).decode("utf-8")
-        if platform.system() == "Windows":
+        system = platform.system()
+        if system == "Windows":
             self.socket = WinNamedPipe(win32file.GENERIC_READ | win32file.GENERIC_WRITE, win32file.OPEN_EXISTING)
+        elif system.startswith("CYGWIN_NT"):
+            self.socket = CygwinPipe()
         else:
             self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             
@@ -91,7 +118,7 @@ class Connection:
             return os.path.join(os.environ["XDG_RUNTIME_DIR"], server_name)
         elif system == "Darwin" and "TMPDIR" in os.environ:
             return os.path.join(os.getenv("TMPDIR"), server_name)
-        elif system == "Windows":
+        elif system == "Windows" or system.startswith("CYGWIN_NT"):
             pathWin = "org.keepassxc.KeePassXC.BrowserServer_"  + getpass.getuser()
             return pathWin
         else:

--- a/keepassxc_proxy_client/protocol.py
+++ b/keepassxc_proxy_client/protocol.py
@@ -58,12 +58,13 @@ class WinNamedPipe:
 
 
 class CygwinPipe:
-    def __init__(self):
+    def __init__(self, flags):
+        self.flags = flags
         self.fd = None
 
     def connect(self, address):
         try:
-            self.fd = os.open(r"\\.\pipe\%s" % address, os.O_RDWR | os.O_BINARY)
+            self.fd = os.open(r"\\.\pipe\%s" % address, self.flags)
         except Exception as e:
             raise Exception(
                 "Error: Connection could not be established to pipe {addr}".format(addr=address), e
@@ -91,7 +92,7 @@ class Connection:
         if system == "Windows":
             self.socket = WinNamedPipe(win32file.GENERIC_READ | win32file.GENERIC_WRITE, win32file.OPEN_EXISTING)
         elif system.startswith("CYGWIN_NT"):
-            self.socket = CygwinPipe()
+            self.socket = CygwinPipe(os.O_RDWR | os.O_BINARY)
         else:
             self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             


### PR DESCRIPTION
### Description

This PR introduces support for **Cygwin** environments.

Cygwin emulates a native Unix-like system. As a result, the existing logic incorrectly attempts to communicate with KeePassXC via a standard Unix socket. However, the Windows implementation of KeePassXC provides a **Win32 named pipe**.

To bridge this gap, this change implements a `CygwinPipe` class. By using `os.open` with `\\.\pipe\` paths, we can interface with the Windows named pipe directly.

**Why this approach?**

* **Compatibility:** `pywin32` is not easily installable (or often not available at all) under Cygwin's Python distribution.
* **Simplicity:** This avoids the need for complex `ctypes` wrappers to call the Windows API, relying instead on the fact that Cygwin can handle Windows device paths when opened in binary mode.

### Key Changes

* **New `CygwinPipe` Class:**
    * Provides a socket-like interface (`connect`, `close`, `sendall`, `recv`).
    * Uses `os.open` with `os.O_RDWR | os.O_BINARY` to interact with the Windows pipe filesystem directly from the Cygwin layer.

* **Platform Detection Logic:**
    * Updated the `Connection` class to check for `system.startswith("CYGWIN_NT")`.
    * Ensures that when running under Cygwin, the client bypasses the `AF_UNIX` socket logic in favor of the new `CygwinPipe`.

* **Path Resolution:**
    * Updated `get_socket_path()` to treat Cygwin similarly to Windows, utilizing the named pipe naming convention: `org.keepassxc.KeePassXC.BrowserServer_<user>`.

* **Global Imports:**
    * Moved `import getpass` to the top level to ensure availability across all platform branches, as it is now required for both native Windows and Cygwin paths.

### How to Test

1. **Environment:** Open a Cygwin terminal.
2. **Configuration:** Ensure KeePassXC is running on the host Windows machine with "Browser Integration" enabled.
3. **Execution:** Perform `keepassxc_proxy_client` actions.
    * **Expected Result:** The client should successfully connect to the named pipe, perform the public key exchange, and be able to retrieve database entries.

```
$ powershell -Command '(gci \\.\pipe\ | ? Name -Like "org.keepassxc.KeePassXC.BrowserServer_*").FullName'
\\.\pipe\org.keepassxc.KeePassXC.BrowserServer_Steve

$ ps -W | awk 'NR == 1 || $0 ~ /KeePassXC\.exe$/'
      PID    PPID    PGID     WINPID   TTY         UID    STIME COMMAND
  4201848       0       0       7544  ?              0   May 12 C:\Program Files\KeePassXC\KeePassXC.exe

$ uname
CYGWIN_NT-10.0-19045

$ keepassxc_proxy_client create > ~/.kpc.json

$ perl -pe 's/[^"]+(?="})/REDACTED/' ~/.kpc.json
{"name": "CLI", "public_key": "REDACTED"}

$ keepassxc_proxy_client get ~/.kpc.json https://example.org/
Hello, world
```