### PR TITLE
Argparse added

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,12 +15,10 @@ authors = [
 ]
 keywords = ["keepassxc", "keepass", "browser-integration", "secrets", "cli"]
 classifiers = [
-    "Development Status :: 4 - Beta",
     "Environment :: Console",
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "Intended Audience :: Information Technology",
-    "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/src/keepassxc_proxy_client/__main__.py
+++ b/src/keepassxc_proxy_client/__main__.py
@@ -1,9 +1,6 @@
 import sys
-import json
-import base64
 
-import keepassxc_proxy_client
-import keepassxc_proxy_client.protocol
+from keepassxc_proxy_client import commands
 
 USAGE = """usage: keepassxc_proxy_client
 
@@ -30,104 +27,29 @@ If the database is already unlocked it has no effect.
 
 
 def main():
-    if len(sys.argv) < 2 or sys.argv[1] in ["-h", "--help","help", "h"]:
+    if len(sys.argv) < 2 or sys.argv[1] in ["-h", "--help", "help", "h"]:
         print(USAGE)
         sys.exit(0)
 
     command = sys.argv[1]
 
     if command == "create":
-        connection = keepassxc_proxy_client.protocol.Connection()
-        connection.connect()
-        connection.associate()
-
-        if not connection.test_associate():
-            print("For some reason the newly created association is invalid, this should not be happening")
-            sys.exit(1)
-
-        name, public_key = connection.dump_associate()
-        out = {
-            "name": name,
-            "public_key": base64.b64encode(public_key).decode("utf-8")
-        }
-        print(json.dumps(out))
-        sys.exit(0)
-
+        sys.exit(commands.create())
     elif command == "get":
         if len(sys.argv) < 4:
             print("Too little arguments provided, see --help for usage")
             sys.exit(1)
-
-        associate_file = sys.argv[2]
-        url = sys.argv[3]
-
-        association = json.load(open(associate_file, "r"))
-
-        connection = keepassxc_proxy_client.protocol.Connection()
-        connection.connect()
-        connection.load_associate(
-            association["name"],
-            base64.b64decode(association["public_key"].encode("utf-8"))
-        )
-
-        if not connection.test_associate():
-            print("The loaded association is invalid")
-            sys.exit(1)
-
-        logins = connection.get_logins(url)
-        if not logins:
-            print("No logins found for the given URL")
-            sys.exit(1)
-
-        print(logins[0]["password"])
-        sys.exit(0)
-    elif command == "unlock":
-        if len(sys.argv) < 3:
-            print("Too few arguments provided, see --help for usage")
-            sys.exit(1)
-
-        associate_file = sys.argv[2]
-        association = json.load(open(associate_file, "r"))
-
-        connection = keepassxc_proxy_client.protocol.Connection()
-        connection.connect()
-
-        connection.load_associate(
-            association["name"],
-            base64.b64decode(association["public_key"].encode("utf-8"))
-        )
-
-        print(connection.test_associate(True))
-
-        sys.exit(0)
+        sys.exit(commands.get(sys.argv[2], sys.argv[3]))
     elif command == "totp":
         if len(sys.argv) < 4:
             print("Too little arguments provided, see --help for usage")
             sys.exit(1)
-
-        associate_file = sys.argv[2]
-        uuid = sys.argv[3]
-
-        association = json.load(open(associate_file, "r"))
-
-        connection = keepassxc_proxy_client.protocol.Connection()
-        connection.connect()
-        connection.load_associate(
-            association["name"],
-            base64.b64decode(association["public_key"].encode("utf-8"))
-        )
-
-        if not connection.test_associate():
-            print("The loaded association is invalid")
+        sys.exit(commands.totp(sys.argv[2], sys.argv[3]))
+    elif command == "unlock":
+        if len(sys.argv) < 3:
+            print("Too few arguments provided, see --help for usage")
             sys.exit(1)
-
-        totp = connection.get_totp(uuid)
-        if not totp:
-            print("No totp found for the given UUID")
-            sys.exit(1)
-
-        print(totp)
-        sys.exit(0)
+        sys.exit(commands.unlock(sys.argv[2]))
     else:
         print("Unkown subcommand, see --help for usage")
         sys.exit(1)

--- a/src/keepassxc_proxy_client/__main__.py
+++ b/src/keepassxc_proxy_client/__main__.py
@@ -1,55 +1,73 @@
-import sys
+import argparse
 
 from keepassxc_proxy_client import commands
 
-USAGE = """usage: keepassxc_proxy_client
 
-keepassxc_proxy_client create: Connects to a locally running keepassxc instance,
-creates a new association with it (this will prompt a dialogue from keepassxc)
-and prints it to stdout as JSON. Note that the public key that is printed is
-secret and can allow anyone with access to your local machine access to all
-passwords that are related to a URL, thus it should be stored safely.
+def build_parser():
+    parser = argparse.ArgumentParser(
+        prog="keepassxc_proxy_client",
+        description="Client for the KeePassXC Browser Integration protocol.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True, metavar="<command>")
 
-keepassxc_proxy_client get <file> <url>: Reads a keepassxc association from
-<file> and attempts to get the first password for <url>. Will exit with 1 if the
-association is not valid for the running keepassxc instance or the no logins are
-found for the given URL.
+    p_create = sub.add_parser(
+        "create",
+        help="Create a new association with a running KeePassXC instance.",
+        description=(
+            "Connects to a locally running keepassxc instance and creates a new "
+            "association (this will prompt a dialogue from KeePassXC). The "
+            "association is printed to stdout as JSON. Note that the public key "
+            "printed is secret and should be stored safely."
+        ),
+    )
+    p_create.set_defaults(func=commands.cmd_create)
 
-keepassxc_proxy_client totp <file> <uuid>: Reads a keepassxc association from
-<file> and attempts to get the current totp for <uuid>. Will exit with 1 if the
-association is not valid for the running keepassxc instance or the no totp is
-found for the given UUID.
+    p_get = sub.add_parser(
+        "get",
+        help="Get the first password for an entry matched by URL.",
+        description=(
+            "Reads a keepassxc association from <file> and attempts to get the "
+            "first password for <url>. Exits with 1 if the association is not "
+            "valid for the running keepassxc instance or no logins are found."
+        ),
+    )
+    p_get.add_argument("file", help="Path to the association JSON file.")
+    p_get.add_argument("url", help="URL to look up.")
+    p_get.set_defaults(func=commands.cmd_get)
 
-keepassxc_proxy_client unlock <file>: Causes a running KeepassXC instance
-to launch a dialogue window to allow the user to unlock a locked database.
-If the database is already unlocked it has no effect.
-"""
+    p_totp = sub.add_parser(
+        "totp",
+        help="Get the current TOTP for an entry UUID.",
+        description=(
+            "Reads a keepassxc association from <file> and attempts to get the "
+            "current TOTP for <uuid>. Exits with 1 if the association is not "
+            "valid for the running keepassxc instance or no TOTP is found."
+        ),
+    )
+    p_totp.add_argument("file", help="Path to the association JSON file.")
+    p_totp.add_argument("uuid", help="Entry UUID.")
+    p_totp.set_defaults(func=commands.cmd_totp)
+
+    p_unlock = sub.add_parser(
+        "unlock",
+        help="Ask KeePassXC to prompt the user to unlock a database.",
+        description=(
+            "Causes a running KeePassXC instance to launch a dialogue window to "
+            "allow the user to unlock a locked database. If the database is "
+            "already unlocked it has no effect."
+        ),
+    )
+    p_unlock.add_argument("file", help="Path to the association JSON file.")
+    p_unlock.set_defaults(func=commands.cmd_unlock)
+
+    return parser
 
 
 def main():
-    if len(sys.argv) < 2 or sys.argv[1] in ["-h", "--help", "help", "h"]:
-        print(USAGE)
-        sys.exit(0)
+    parser = build_parser()
+    args = parser.parse_args()
+    args.func(args)
 
-    command = sys.argv[1]
 
-    if command == "create":
-        sys.exit(commands.create())
-    elif command == "get":
-        if len(sys.argv) < 4:
-            print("Too little arguments provided, see --help for usage")
-            sys.exit(1)
-        sys.exit(commands.get(sys.argv[2], sys.argv[3]))
-    elif command == "totp":
-        if len(sys.argv) < 4:
-            print("Too little arguments provided, see --help for usage")
-            sys.exit(1)
-        sys.exit(commands.totp(sys.argv[2], sys.argv[3]))
-    elif command == "unlock":
-        if len(sys.argv) < 3:
-            print("Too few arguments provided, see --help for usage")
-            sys.exit(1)
-        sys.exit(commands.unlock(sys.argv[2]))
-    else:
-        print("Unkown subcommand, see --help for usage")
-        sys.exit(1)
+if __name__ == "__main__":
+    main()

--- a/src/keepassxc_proxy_client/commands.py
+++ b/src/keepassxc_proxy_client/commands.py
@@ -5,22 +5,21 @@ import keepassxc_proxy_client.protocol
 from keepassxc_proxy_client import keystore
 
 
-def create():
+def cmd_create(args):
     connection = keepassxc_proxy_client.protocol.Connection()
     connection.connect()
     connection.associate()
 
     if not connection.test_associate():
         print("For some reason the newly created association is invalid, this should not be happening")
-        return 1
+        sys.exit(1)
 
     name, public_key = connection.dump_associate()
     print(json.dumps(keystore.dump_association(name, public_key)))
-    return 0
 
 
-def get(associate_file, url):
-    name, public_key = keystore.load_association(associate_file)
+def cmd_get(args):
+    name, public_key = keystore.load_association(args.file)
 
     connection = keepassxc_proxy_client.protocol.Connection()
     connection.connect()
@@ -28,19 +27,18 @@ def get(associate_file, url):
 
     if not connection.test_associate():
         print("The loaded association is invalid")
-        return 1
+        sys.exit(1)
 
-    logins = connection.get_logins(url)
+    logins = connection.get_logins(args.url)
     if not logins:
         print("No logins found for the given URL")
-        return 1
+        sys.exit(1)
 
     print(logins[0]["password"])
-    return 0
 
 
-def totp(associate_file, uuid):
-    name, public_key = keystore.load_association(associate_file)
+def cmd_totp(args):
+    name, public_key = keystore.load_association(args.file)
 
     connection = keepassxc_proxy_client.protocol.Connection()
     connection.connect()
@@ -48,23 +46,21 @@ def totp(associate_file, uuid):
 
     if not connection.test_associate():
         print("The loaded association is invalid")
-        return 1
+        sys.exit(1)
 
-    totp_value = connection.get_totp(uuid)
+    totp_value = connection.get_totp(args.uuid)
     if not totp_value:
         print("No totp found for the given UUID")
-        return 1
+        sys.exit(1)
 
     print(totp_value)
-    return 0
 
 
-def unlock(associate_file):
-    name, public_key = keystore.load_association(associate_file)
+def cmd_unlock(args):
+    name, public_key = keystore.load_association(args.file)
 
     connection = keepassxc_proxy_client.protocol.Connection()
     connection.connect()
     connection.load_associate(name, public_key)
 
     print(connection.test_associate(True))
-    return 0

--- a/src/keepassxc_proxy_client/commands.py
+++ b/src/keepassxc_proxy_client/commands.py
@@ -1,0 +1,70 @@
+import json
+import sys
+
+import keepassxc_proxy_client.protocol
+from keepassxc_proxy_client import keystore
+
+
+def create():
+    connection = keepassxc_proxy_client.protocol.Connection()
+    connection.connect()
+    connection.associate()
+
+    if not connection.test_associate():
+        print("For some reason the newly created association is invalid, this should not be happening")
+        return 1
+
+    name, public_key = connection.dump_associate()
+    print(json.dumps(keystore.dump_association(name, public_key)))
+    return 0
+
+
+def get(associate_file, url):
+    name, public_key = keystore.load_association(associate_file)
+
+    connection = keepassxc_proxy_client.protocol.Connection()
+    connection.connect()
+    connection.load_associate(name, public_key)
+
+    if not connection.test_associate():
+        print("The loaded association is invalid")
+        return 1
+
+    logins = connection.get_logins(url)
+    if not logins:
+        print("No logins found for the given URL")
+        return 1
+
+    print(logins[0]["password"])
+    return 0
+
+
+def totp(associate_file, uuid):
+    name, public_key = keystore.load_association(associate_file)
+
+    connection = keepassxc_proxy_client.protocol.Connection()
+    connection.connect()
+    connection.load_associate(name, public_key)
+
+    if not connection.test_associate():
+        print("The loaded association is invalid")
+        return 1
+
+    totp_value = connection.get_totp(uuid)
+    if not totp_value:
+        print("No totp found for the given UUID")
+        return 1
+
+    print(totp_value)
+    return 0
+
+
+def unlock(associate_file):
+    name, public_key = keystore.load_association(associate_file)
+
+    connection = keepassxc_proxy_client.protocol.Connection()
+    connection.connect()
+    connection.load_associate(name, public_key)
+
+    print(connection.test_associate(True))
+    return 0

--- a/src/keepassxc_proxy_client/keystore.py
+++ b/src/keepassxc_proxy_client/keystore.py
@@ -1,0 +1,14 @@
+import base64
+import json
+
+
+def load_association(path):
+    data = json.load(open(path, "r"))
+    return data["name"], base64.b64decode(data["public_key"].encode("utf-8"))
+
+
+def dump_association(name, public_key):
+    return {
+        "name": name,
+        "public_key": base64.b64encode(public_key).decode("utf-8"),
+    }


### PR DESCRIPTION
Hello Henrik,

thanks for the previous PR merge. This one deals two key changes:

- Module __main__.py is split into separate logical blocks (files).
- Manually written command parsing is replaced with argparse module.

My justification for the additional dependency on argparse is:

- It's easily human-readable.
- It's self-documentation - allowing us to drop the long commentary at the start of __main__.py.
- It prepares the project for more CLI options in the future.

Thank you in advance for any time you'd spend on this. I'm happy for any comments and suggestions.
Marek