### PR TITLE
Keystore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
 ]
 dependencies = [
     "pynacl",
+    "platformdirs",
     "pywin32; sys_platform == 'win32'",
 ]
 

--- a/src/keepassxc_proxy_client/__main__.py
+++ b/src/keepassxc_proxy_client/__main__.py
@@ -1,15 +1,19 @@
 import argparse
 
-from keepassxc_proxy_client import commands
+from keepassxc_proxy_client import commands, keystore
 
 
-_FILE_HELP = (
-    "Path to the keystore JSON file. If omitted, the OS-default location is "
-    "used (see keystore.default_path)."
-)
+def _add_file_arg(p, default):
+    p.add_argument(
+        "--file",
+        "-f",
+        default=default,
+        help="Path to the keystore JSON file. Defaults to %(default)s.",
+    )
 
 
 def build_parser():
+    default_keystore = keystore.default_path()
     parser = argparse.ArgumentParser(
         prog="keepassxc_proxy_client",
         description="Client for the KeePassXC Browser Integration protocol.",
@@ -27,7 +31,7 @@ def build_parser():
             "KeePassXC."
         ),
     )
-    p_create.add_argument("file", nargs="?", default=None, help=_FILE_HELP)
+    _add_file_arg(p_create, default_keystore)
     p_create.add_argument(
         "--save",
         "-s",
@@ -45,13 +49,13 @@ def build_parser():
         "get",
         help="Get the first password for an entry matched by URL.",
         description=(
-            "Reads keepassxc associations from <file> and attempts to get the "
-            "first password for <url>. Each stored association is tried until "
-            "one authenticates. Exits with 1 if no association authenticates "
-            "or no logins are found."
+            "Reads keepassxc associations from the keystore file and attempts "
+            "to get the first password for <url>. Each stored association is "
+            "tried until one authenticates. Exits with 1 if no association "
+            "authenticates or no logins are found."
         ),
     )
-    p_get.add_argument("file", help="Path to the keystore JSON file.")
+    _add_file_arg(p_get, default_keystore)
     p_get.add_argument("url", help="URL to look up.")
     p_get.set_defaults(func=commands.cmd_get)
 
@@ -59,13 +63,13 @@ def build_parser():
         "totp",
         help="Get the current TOTP for an entry UUID.",
         description=(
-            "Reads keepassxc associations from <file> and attempts to get the "
-            "current TOTP for <uuid>. Each stored association is tried until "
-            "one authenticates. Exits with 1 if no association authenticates "
-            "or no TOTP is found."
+            "Reads keepassxc associations from the keystore file and attempts "
+            "to get the current TOTP for <uuid>. Each stored association is "
+            "tried until one authenticates. Exits with 1 if no association "
+            "authenticates or no TOTP is found."
         ),
     )
-    p_totp.add_argument("file", help="Path to the keystore JSON file.")
+    _add_file_arg(p_totp, default_keystore)
     p_totp.add_argument("uuid", help="Entry UUID.")
     p_totp.set_defaults(func=commands.cmd_totp)
 
@@ -78,7 +82,7 @@ def build_parser():
             "already unlocked it has no effect."
         ),
     )
-    p_unlock.add_argument("file", nargs="?", default=None, help=_FILE_HELP)
+    _add_file_arg(p_unlock, default_keystore)
     p_unlock.set_defaults(func=commands.cmd_unlock)
 
     return parser

--- a/src/keepassxc_proxy_client/__main__.py
+++ b/src/keepassxc_proxy_client/__main__.py
@@ -12,6 +12,19 @@ def _add_file_arg(p, default):
     )
 
 
+def _add_id_arg(p):
+    p.add_argument(
+        "--id",
+        "-i",
+        dest="id",
+        default=None,
+        help=(
+            "Association id to use. If omitted, all stored associations are tried "
+            "in turn until one authenticates successfully."
+        ),
+    )
+
+
 def build_parser():
     default_keystore = keystore.default_path()
     parser = argparse.ArgumentParser(
@@ -56,6 +69,7 @@ def build_parser():
         ),
     )
     _add_file_arg(p_get, default_keystore)
+    _add_id_arg(p_get)
     p_get.add_argument("url", help="URL to look up.")
     p_get.set_defaults(func=commands.cmd_get)
 
@@ -70,6 +84,7 @@ def build_parser():
         ),
     )
     _add_file_arg(p_totp, default_keystore)
+    _add_id_arg(p_totp)
     p_totp.add_argument("uuid", help="Entry UUID.")
     p_totp.set_defaults(func=commands.cmd_totp)
 
@@ -83,6 +98,7 @@ def build_parser():
         ),
     )
     _add_file_arg(p_unlock, default_keystore)
+    _add_id_arg(p_unlock)
     p_unlock.set_defaults(func=commands.cmd_unlock)
 
     return parser

--- a/src/keepassxc_proxy_client/__main__.py
+++ b/src/keepassxc_proxy_client/__main__.py
@@ -21,12 +21,24 @@ def build_parser():
         help="Create a new association with a running KeePassXC instance.",
         description=(
             "Connects to a locally running keepassxc instance and creates a new "
-            "association (this will prompt a dialogue from KeePassXC). The "
-            "association is printed to stdout as JSON. Note that the public key "
-            "printed is secret and should be stored safely."
+            "association (this will prompt a dialogue from KeePassXC). Without "
+            "--save the association is printed to stdout as JSON. With --save it "
+            "is persisted to the keystore file under the id returned by "
+            "KeePassXC."
         ),
     )
     p_create.add_argument("file", nargs="?", default=None, help=_FILE_HELP)
+    p_create.add_argument(
+        "--save",
+        "-s",
+        action="store_true",
+        help="Persist the new association to the keystore file instead of printing it.",
+    )
+    p_create.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite an existing association with the same id (use with --save).",
+    )
     p_create.set_defaults(func=commands.cmd_create)
 
     p_get = sub.add_parser(

--- a/src/keepassxc_proxy_client/__main__.py
+++ b/src/keepassxc_proxy_client/__main__.py
@@ -3,6 +3,12 @@ import argparse
 from keepassxc_proxy_client import commands
 
 
+_FILE_HELP = (
+    "Path to the keystore JSON file. If omitted, the OS-default location is "
+    "used (see keystore.default_path)."
+)
+
+
 def build_parser():
     parser = argparse.ArgumentParser(
         prog="keepassxc_proxy_client",
@@ -20,18 +26,20 @@ def build_parser():
             "printed is secret and should be stored safely."
         ),
     )
+    p_create.add_argument("file", nargs="?", default=None, help=_FILE_HELP)
     p_create.set_defaults(func=commands.cmd_create)
 
     p_get = sub.add_parser(
         "get",
         help="Get the first password for an entry matched by URL.",
         description=(
-            "Reads a keepassxc association from <file> and attempts to get the "
-            "first password for <url>. Exits with 1 if the association is not "
-            "valid for the running keepassxc instance or no logins are found."
+            "Reads keepassxc associations from <file> and attempts to get the "
+            "first password for <url>. Each stored association is tried until "
+            "one authenticates. Exits with 1 if no association authenticates "
+            "or no logins are found."
         ),
     )
-    p_get.add_argument("file", help="Path to the association JSON file.")
+    p_get.add_argument("file", help="Path to the keystore JSON file.")
     p_get.add_argument("url", help="URL to look up.")
     p_get.set_defaults(func=commands.cmd_get)
 
@@ -39,12 +47,13 @@ def build_parser():
         "totp",
         help="Get the current TOTP for an entry UUID.",
         description=(
-            "Reads a keepassxc association from <file> and attempts to get the "
-            "current TOTP for <uuid>. Exits with 1 if the association is not "
-            "valid for the running keepassxc instance or no TOTP is found."
+            "Reads keepassxc associations from <file> and attempts to get the "
+            "current TOTP for <uuid>. Each stored association is tried until "
+            "one authenticates. Exits with 1 if no association authenticates "
+            "or no TOTP is found."
         ),
     )
-    p_totp.add_argument("file", help="Path to the association JSON file.")
+    p_totp.add_argument("file", help="Path to the keystore JSON file.")
     p_totp.add_argument("uuid", help="Entry UUID.")
     p_totp.set_defaults(func=commands.cmd_totp)
 
@@ -57,7 +66,7 @@ def build_parser():
             "already unlocked it has no effect."
         ),
     )
-    p_unlock.add_argument("file", help="Path to the association JSON file.")
+    p_unlock.add_argument("file", nargs="?", default=None, help=_FILE_HELP)
     p_unlock.set_defaults(func=commands.cmd_unlock)
 
     return parser

--- a/src/keepassxc_proxy_client/commands.py
+++ b/src/keepassxc_proxy_client/commands.py
@@ -6,10 +6,6 @@ import keepassxc_proxy_client.protocol
 from keepassxc_proxy_client import keystore
 
 
-def _resolve_path(args):
-    return args.file if args.file else keystore.default_path()
-
-
 def _authenticate(connection, path):
     """Try every association stored at `path` until one authenticates.
 
@@ -43,7 +39,7 @@ def cmd_create(args):
     name, public_key = connection.dump_associate()
 
     if args.save:
-        path = _resolve_path(args)
+        path = args.file
         try:
             keystore.save(path, name, public_key, force=args.force)
         except keystore.AssociationExists as e:
@@ -63,7 +59,7 @@ def cmd_create(args):
 
 
 def cmd_get(args):
-    path = _resolve_path(args)
+    path = args.file
 
     connection = keepassxc_proxy_client.protocol.Connection()
     connection.connect()
@@ -79,7 +75,7 @@ def cmd_get(args):
 
 
 def cmd_totp(args):
-    path = _resolve_path(args)
+    path = args.file
 
     connection = keepassxc_proxy_client.protocol.Connection()
     connection.connect()
@@ -95,7 +91,7 @@ def cmd_totp(args):
 
 
 def cmd_unlock(args):
-    path = _resolve_path(args)
+    path = args.file
 
     connection = keepassxc_proxy_client.protocol.Connection()
     connection.connect()

--- a/src/keepassxc_proxy_client/commands.py
+++ b/src/keepassxc_proxy_client/commands.py
@@ -41,6 +41,18 @@ def cmd_create(args):
         sys.exit(1)
 
     name, public_key = connection.dump_associate()
+
+    if args.save:
+        path = _resolve_path(args)
+        try:
+            keystore.save(path, name, public_key, force=args.force)
+        except keystore.AssociationExists as e:
+            print(str(e))
+            print("Re-run with --force to overwrite.")
+            sys.exit(1)
+        print("Saved association %r to %s" % (name, path))
+        return
+
     out = {
         "version": keystore.SCHEMA_VERSION,
         "associations": {

--- a/src/keepassxc_proxy_client/commands.py
+++ b/src/keepassxc_proxy_client/commands.py
@@ -6,20 +6,36 @@ import keepassxc_proxy_client.protocol
 from keepassxc_proxy_client import keystore
 
 
-def _authenticate(connection, path):
-    """Try every association stored at `path` until one authenticates.
+def _authenticate(connection, path, assoc_id=None):
+    """Authenticate against a keystore.
+
+    If `assoc_id` is given, only that association is tried. Otherwise every
+    stored association is tried until one authenticates.
 
     Returns True on success. Prints a diagnostic and returns False if the
-    keystore is empty or no candidate authenticated.
+    keystore is empty, the requested id is missing, or no candidate
+    authenticated.
     """
+    if assoc_id is not None:
+        try:
+            key_bytes = keystore.load(path, assoc_id)
+        except keystore.AssociationNotFound as e:
+            print(str(e))
+            return False
+        connection.load_associate(assoc_id, key_bytes)
+        if connection.test_associate():
+            return True
+        print("Association %r did not authenticate against the running KeePassXC instance" % assoc_id)
+        return False
+
     ids = keystore.list_associations(path)
     if not ids:
         print("No associations stored in %s" % path)
         return False
 
-    for assoc_id in ids:
-        key_bytes = keystore.load(path, assoc_id)
-        connection.load_associate(assoc_id, key_bytes)
+    for candidate in ids:
+        key_bytes = keystore.load(path, candidate)
+        connection.load_associate(candidate, key_bytes)
         if connection.test_associate():
             return True
 
@@ -63,7 +79,7 @@ def cmd_get(args):
 
     connection = keepassxc_proxy_client.protocol.Connection()
     connection.connect()
-    if not _authenticate(connection, path):
+    if not _authenticate(connection, path, args.id):
         sys.exit(1)
 
     logins = connection.get_logins(args.url)
@@ -79,7 +95,7 @@ def cmd_totp(args):
 
     connection = keepassxc_proxy_client.protocol.Connection()
     connection.connect()
-    if not _authenticate(connection, path):
+    if not _authenticate(connection, path, args.id):
         sys.exit(1)
 
     totp_value = connection.get_totp(args.uuid)
@@ -95,7 +111,7 @@ def cmd_unlock(args):
 
     connection = keepassxc_proxy_client.protocol.Connection()
     connection.connect()
-    if not _authenticate(connection, path):
+    if not _authenticate(connection, path, args.id):
         sys.exit(1)
 
     print(connection.test_associate(True))

--- a/src/keepassxc_proxy_client/commands.py
+++ b/src/keepassxc_proxy_client/commands.py
@@ -1,8 +1,34 @@
+import base64
 import json
 import sys
 
 import keepassxc_proxy_client.protocol
 from keepassxc_proxy_client import keystore
+
+
+def _resolve_path(args):
+    return args.file if args.file else keystore.default_path()
+
+
+def _authenticate(connection, path):
+    """Try every association stored at `path` until one authenticates.
+
+    Returns True on success. Prints a diagnostic and returns False if the
+    keystore is empty or no candidate authenticated.
+    """
+    ids = keystore.list_associations(path)
+    if not ids:
+        print("No associations stored in %s" % path)
+        return False
+
+    for assoc_id in ids:
+        key_bytes = keystore.load(path, assoc_id)
+        connection.load_associate(assoc_id, key_bytes)
+        if connection.test_associate():
+            return True
+
+    print("None of the stored associations authenticated against the running KeePassXC instance")
+    return False
 
 
 def cmd_create(args):
@@ -15,18 +41,21 @@ def cmd_create(args):
         sys.exit(1)
 
     name, public_key = connection.dump_associate()
-    print(json.dumps(keystore.dump_association(name, public_key)))
+    out = {
+        "version": keystore.SCHEMA_VERSION,
+        "associations": {
+            name: base64.b64encode(public_key).decode("ascii"),
+        },
+    }
+    print(json.dumps(out))
 
 
 def cmd_get(args):
-    name, public_key = keystore.load_association(args.file)
+    path = _resolve_path(args)
 
     connection = keepassxc_proxy_client.protocol.Connection()
     connection.connect()
-    connection.load_associate(name, public_key)
-
-    if not connection.test_associate():
-        print("The loaded association is invalid")
+    if not _authenticate(connection, path):
         sys.exit(1)
 
     logins = connection.get_logins(args.url)
@@ -38,14 +67,11 @@ def cmd_get(args):
 
 
 def cmd_totp(args):
-    name, public_key = keystore.load_association(args.file)
+    path = _resolve_path(args)
 
     connection = keepassxc_proxy_client.protocol.Connection()
     connection.connect()
-    connection.load_associate(name, public_key)
-
-    if not connection.test_associate():
-        print("The loaded association is invalid")
+    if not _authenticate(connection, path):
         sys.exit(1)
 
     totp_value = connection.get_totp(args.uuid)
@@ -57,10 +83,11 @@ def cmd_totp(args):
 
 
 def cmd_unlock(args):
-    name, public_key = keystore.load_association(args.file)
+    path = _resolve_path(args)
 
     connection = keepassxc_proxy_client.protocol.Connection()
     connection.connect()
-    connection.load_associate(name, public_key)
+    if not _authenticate(connection, path):
+        sys.exit(1)
 
     print(connection.test_associate(True))

--- a/src/keepassxc_proxy_client/keystore.py
+++ b/src/keepassxc_proxy_client/keystore.py
@@ -1,14 +1,186 @@
+"""On-disk persistence for KeePassXC Browser Integration associations.
+
+The keystore is a JSON file with this schema:
+
+    {
+        "version": 1,
+        "associations": {
+            "<assoc id from KeePassXC>": "<base64-encoded idKey>"
+        }
+    }
+
+The default location is OS-appropriate (via platformdirs):
+
+    Linux/BSD:  $XDG_CONFIG_HOME/keepassxc-proxy-client/keys.json
+                (fallback: ~/.config/keepassxc-proxy-client/keys.json)
+    macOS:      ~/Library/Application Support/keepassxc-proxy-client/keys.json
+    Windows:    %APPDATA%\\keepassxc-proxy-client\\keys.json
+
+On POSIX, the directory is created with mode 0700 and the file with 0600.
+On Windows, file permissions rely on the user profile ACL.
+"""
 import base64
 import json
+import os
+import platform
+import tempfile
+
+APP_NAME = "keepassxc-proxy-client"
+KEYSTORE_FILENAME = "keys.json"
+SCHEMA_VERSION = 1
 
 
-def load_association(path):
-    data = json.load(open(path, "r"))
-    return data["name"], base64.b64decode(data["public_key"].encode("utf-8"))
+class KeystoreError(Exception):
+    pass
 
 
-def dump_association(name, public_key):
-    return {
-        "name": name,
-        "public_key": base64.b64encode(public_key).decode("utf-8"),
-    }
+class KeystoreFormatError(KeystoreError):
+    pass
+
+
+class AssociationExists(KeystoreError):
+    pass
+
+
+class AssociationNotFound(KeystoreError):
+    pass
+
+
+def default_path():
+    """Return the OS-appropriate path to the user's keystore file."""
+    try:
+        import platformdirs
+    except ImportError as e:
+        raise KeystoreError(
+            "platformdirs is required to resolve the default keystore path; "
+            "install it or pass an explicit file path"
+        ) from e
+    config_dir = platformdirs.user_config_dir(APP_NAME, appauthor=False, roaming=True)
+    return os.path.join(config_dir, KEYSTORE_FILENAME)
+
+
+def _empty_store():
+    return {"version": SCHEMA_VERSION, "associations": {}}
+
+
+def _migrate_legacy(data):
+    """Convert the pre-schema single-association shape into the current schema.
+
+    Older `create` output looked like {"name": ..., "public_key": ...}. Detect
+    that shape and lift it into the versioned multi-association form so read
+    paths keep working. Returns data unchanged if it isn't the legacy shape.
+    """
+    if isinstance(data, dict) and "version" not in data \
+            and set(data.keys()) == {"name", "public_key"}:
+        return {
+            "version": SCHEMA_VERSION,
+            "associations": {data["name"]: data["public_key"]},
+        }
+    return data
+
+
+def _validate(data):
+    if not isinstance(data, dict):
+        raise KeystoreFormatError("keystore root must be an object")
+    if data.get("version") != SCHEMA_VERSION:
+        raise KeystoreFormatError(
+            "unsupported or missing keystore version (expected %d)" % SCHEMA_VERSION
+        )
+    assoc = data.get("associations")
+    if not isinstance(assoc, dict):
+        raise KeystoreFormatError("`associations` must be an object")
+    for assoc_id, key in assoc.items():
+        if not isinstance(key, str):
+            raise KeystoreFormatError("association %r value must be a base64 string" % assoc_id)
+    return data
+
+
+def read(path):
+    """Load the keystore file. Returns the parsed dict.
+
+    Raises FileNotFoundError if the file does not exist, and KeystoreFormatError
+    if it does not match the expected schema.
+    """
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return _validate(_migrate_legacy(data))
+
+
+def read_or_empty(path):
+    """Like read(), but returns an empty store if the file is missing."""
+    try:
+        return read(path)
+    except FileNotFoundError:
+        return _empty_store()
+
+
+def _atomic_write(path, data):
+    """Write data to path atomically (write to tmp + rename), with 0600 mode on POSIX."""
+    parent = os.path.dirname(path) or "."
+    os.makedirs(parent, exist_ok=True)
+    if platform.system() != "Windows":
+        try:
+            os.chmod(parent, 0o700)
+        except OSError:
+            pass
+
+    fd, tmp = tempfile.mkstemp(prefix=".keys-", suffix=".json", dir=parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, sort_keys=True)
+            f.write("\n")
+        if platform.system() != "Windows":
+            os.chmod(tmp, 0o600)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def list_associations(path):
+    """Return a sorted list of association ids stored at `path`."""
+    data = read_or_empty(path)
+    return sorted(data["associations"].keys())
+
+
+def load(path, assoc_id):
+    """Load a single association from `path` by id.
+
+    Returns the raw idKey bytes. Raises AssociationNotFound if missing.
+    """
+    data = read_or_empty(path)
+    key_b64 = data["associations"].get(assoc_id)
+    if key_b64 is None:
+        raise AssociationNotFound(
+            "association %r not found in %s" % (assoc_id, path)
+        )
+    return base64.b64decode(key_b64.encode("ascii"))
+
+
+def save(path, assoc_id, key_bytes, force=False):
+    """Persist an association to `path`.
+
+    If `assoc_id` already exists and `force` is False, raises AssociationExists.
+    The file is created (with mode 0600 on POSIX) if it does not exist.
+    """
+    data = read_or_empty(path)
+    if assoc_id in data["associations"] and not force:
+        raise AssociationExists(
+            "association %r already exists in %s; use force=True to overwrite" % (assoc_id, path)
+        )
+    data["associations"][assoc_id] = base64.b64encode(key_bytes).decode("ascii")
+    _atomic_write(path, data)
+
+
+def delete(path, assoc_id):
+    """Remove an association from the keystore. Raises AssociationNotFound if missing."""
+    data = read_or_empty(path)
+    if assoc_id not in data["associations"]:
+        raise AssociationNotFound(
+            "association %r not found in %s" % (assoc_id, path)
+        )
+    del data["associations"][assoc_id]
+    _atomic_write(path, data)

--- a/uv.lock
+++ b/uv.lock
@@ -106,14 +106,41 @@ name = "keepassxc-proxy-client"
 version = "0.1.7"
 source = { editable = "." }
 dependencies = [
+    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "platformdirs", version = "4.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pynacl" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "platformdirs" },
     { name = "pynacl" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/e8/21db9c9987b0e728855bd57bff6984f67952bea55d6f75e055c46b5383e8/platformdirs-4.4.0.tar.gz", hash = "sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf", size = 21634, upload-time = "2025-08-26T14:32:04.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/4b/2028861e724d3bd36227adfa20d3fd24c3fc6d52032f4a93c133be5d17ce/platformdirs-4.4.0-py3-none-any.whl", hash = "sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85", size = 18654, upload-time = "2025-08-26T14:32:02.735Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Hello Henrik,

this is perhaps first 'controversial' PR:  it has several additions dealing with making keystore more persistent. These changes currently do not guarantee full backward compatibility.

Key changes:

- Keystore format extended to allow multiple associations in same file
- Keystore can be stored via --save option instead of only being flushed to STDOUT.
- Added dependency on platformdirs - it provides normalized default storage location for keystore on all platforms.
- Mandatory positional file argument converted to --file / -f on all subcommands to permit use of default keystore file.
- Added --id, -i argument to allow targetting only specific association within the keystore file.

Thank you in advance for consideration.

Best regards
Marek